### PR TITLE
Added options for more thumbnail cropping modes

### DIFF
--- a/resources/UberGallery.php
+++ b/resources/UberGallery.php
@@ -740,12 +740,12 @@ class UberGallery {
 		break;
 
 		case "vary":
-	        if ($srcRatio >= $thumbRatio) {
-		    $resizedHeight = $thumbHeight = $thumbWidth * $srcRatio;
+	        if ($thumbRatio>$srcRatio) {
+		    $resizedWidth = $thumbWidth = $thumbHeight * $srcRatio;
 
 	        } else {
 
-		    $resizedWidth = $thumbWidth = $thumbHeight * $srcRatio;
+		    $resizedHeight = $thumbHeight = $thumbWidth / $srcRatio;
 
 	        }
 		break;


### PR DESCRIPTION
Added options for more thumbnail cropping modes
[basic_settings]\thumbnail_cropping_mode:
- "crop" is the usual default, cropping an appropriate part of the image;
- "fit" stuffs the whole image into the thumbnail, with blank (black)
sides
- "vary" lets thumbnails have different sizes, up to width/height
maximum, with no blank sides.